### PR TITLE
[Update Layout] スマホ画面でプレイ時に一画面でプレイできるようにした

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   # Next.jsの環境
   hnz-view:
@@ -9,4 +8,6 @@ services:
     ports:
       - "3030:3030"
     stdin_open: true
-    tty: true
+    tty: true 
+    env_file:
+      - ./view/.env.development.local

--- a/view/src/app/quiz/page.tsx
+++ b/view/src/app/quiz/page.tsx
@@ -63,10 +63,10 @@ export default function Home() {
             <Card className="flex border-4 border-accentcolor">
               <img
                 src={memberImage}
-                width={300}
-                height={300}
+                width={1000}
+                height={1000}
                 alt="memberImage"
-                className="object-center object-cover"
+                className="h-full w-full object-center object-cover"
               />
             </Card>
           </div>

--- a/view/src/app/quiz/page.tsx
+++ b/view/src/app/quiz/page.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { useRouter } from "next/navigation";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { QUIZ_DATA, COLOR } from "@/lib/const";
 import { getColorName } from "@/api/quiz";
 import { PenlightColor } from "@/lib/type";
@@ -72,11 +72,11 @@ export default function Home() {
           </div>
           <div className="flex flex-1 h-1/4 p-5">
             <Card
-              className="flex flex-1 justify-center p-6
+              className="flex-auto justify-center p-6
               text-base sm:text-xl lg:text-2xl
               bg-primarycolor border-4 border-accentcolor"
             >
-              <p>{memberInfo}</p>
+              <textarea name="" id="" className="w-full bg-primarycolor">{memberInfo}</textarea>
             </Card>
           </div>
         </div>

--- a/view/src/app/quiz/page.tsx
+++ b/view/src/app/quiz/page.tsx
@@ -72,11 +72,14 @@ export default function Home() {
           </div>
           <div className="flex flex-1 h-1/4 p-5">
             <Card
-              className="flex-auto justify-center p-6
+              className="flex-auto justify-center p-2
               text-base sm:text-xl lg:text-2xl
               bg-primarycolor border-4 border-accentcolor"
             >
-              <textarea name="" id="" className="w-full bg-primarycolor">{memberInfo}</textarea>
+              <textarea className="h-full w-full bg-primarycolor"
+                        style={{overflow: "auto"}}>
+                {memberInfo}
+              </textarea>
             </Card>
           </div>
         </div>

--- a/view/src/app/quiz/page.tsx
+++ b/view/src/app/quiz/page.tsx
@@ -49,7 +49,7 @@ export default function Home() {
   return (
     <main>
       <div className="flex flex-wrap h-screen">
-        <div className="flex flex-col h-full w-full sm:w-1/2 bg-basecolor">
+        <div className="flex flex-col h-1/2 sm:h-full w-full sm:w-1/2 bg-basecolor">
           <div className="flex flex-1 justify-center items-center h-1/4 p-5">
             <Card
               className="flex flex-1 justify-center p-4
@@ -80,7 +80,7 @@ export default function Home() {
             </Card>
           </div>
         </div>
-        <div className="flex flex-col h-full w-full sm:w-1/2 p-4 justify-around items-center bg-basecolor">
+        <div className="flex flex-col h-1/2 sm:h-full w-full sm:w-1/2 p-4 justify-around items-center bg-basecolor">
           <div className="flex h-3/4 w-full">
             <div className="h-full w-1/2" id="penlightLeft">
               <Penlight handleColorIdChanged={setColorIdLeft} />


### PR DESCRIPTION
## 目的
[Update Layout] スマホ画面でプレイ時に一画面でプレイできるようにした
## 概要
Solve #40 
スマホ画面でプレイする際、ペンライトを選択するにはスクロール必要がありUXが悪かった。
そのため、一画面でプレイできるように修正し、その過程で発生したレイアウト崩れを修正した。

## 確認項目

- [ ] スマホ画面で一画面でプレイできることを確認する
- [ ] パソコン画面でのUXが悪化していないことを確認

## 不安・相談
