### PR TITLE
[Fix Layout] スマホ版のレイアウト崩れを修正

### DIFF
--- a/view/src/app/quiz/page.tsx
+++ b/view/src/app/quiz/page.tsx
@@ -66,7 +66,7 @@ export default function Home() {
                 width={300}
                 height={300}
                 alt="memberImage"
-                className="h-full object-center"
+                className="h-full w-full"
               />
             </Card>
           </div>

--- a/view/src/app/quiz/page.tsx
+++ b/view/src/app/quiz/page.tsx
@@ -63,10 +63,10 @@ export default function Home() {
             <Card className="flex border-4 border-accentcolor">
               <img
                 src={memberImage}
-                width={1000}
-                height={1000}
+                width={300}
+                height={300}
                 alt="memberImage"
-                className="h-full w-full object-center object-cover"
+                className="h-full w-full object-center"
               />
             </Card>
           </div>

--- a/view/src/app/quiz/page.tsx
+++ b/view/src/app/quiz/page.tsx
@@ -66,7 +66,7 @@ export default function Home() {
                 width={300}
                 height={300}
                 alt="memberImage"
-                className="h-full w-full object-center"
+                className="h-full object-center"
               />
             </Card>
           </div>

--- a/view/src/app/quiz/page.tsx
+++ b/view/src/app/quiz/page.tsx
@@ -60,13 +60,13 @@ export default function Home() {
             </Card>
           </div>
           <div className="flex flex-auto h-1/2 justify-center p-4">
-            <Card className="flex border-4 border-accentcolor">
+            <Card className="flex bg-transparent border-none">
               <img
                 src={memberImage}
                 width={300}
                 height={300}
                 alt="memberImage"
-                className="h-full w-full"
+                className="w-full h-full object-contain"
               />
             </Card>
           </div>


### PR DESCRIPTION
## 目的
[Fix Layout] スマホ版のレイアウト崩れを修正
## 概要
Solve #40 
スマホの一画面プレイに対応させた際に、新たなレイアウト崩れが生じたため、修正した
## 確認項目

- [ ] スマホで一画面でプレイできること
- [ ] パソコンのUIが崩れていないこと

## 不安・相談
