### PR TITLE
[Fix Bug] 正しくペンライトIDがAnswer Pageに渡されない問題を解決

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ./view:/view
       - ./view/node_modules:/view/node_modules
     ports:
-      - "3030:3030"
+      - "3031:3031"
     stdin_open: true
     tty: true
     env_file:

--- a/view/Dockerfile
+++ b/view/Dockerfile
@@ -26,8 +26,8 @@ ENV NEXT_TELEMENTRY_DISABLED 1
 COPY --from=deps /view/node_modules ./node_modules
 COPY . .
 
-EXPOSE 3030
+EXPOSE 3031
 
-ENV PORT 3030
+ENV PORT 3031
 
-CMD HOSTNAME="0.0.0.0" PORT=3030 yarn run dev
+CMD HOSTNAME="0.0.0.0" PORT=3031 yarn run dev

--- a/view/src/app/quiz/page.tsx
+++ b/view/src/app/quiz/page.tsx
@@ -17,7 +17,7 @@ type PenlightTopProps = {
 export default function Home() {
   const router = useRouter();
   const quizMember = useQuizMemberStore((state) => state);
-  
+
   if (typeof window === "undefined") return false;
 
   const memberName = quizMember.name;
@@ -25,15 +25,15 @@ export default function Home() {
   const memberInfo = quizMember.memberInfo;
   const leftPenlightStore = createPenlightStore();
   const rightPenlightStore = createPenlightStore();
-  const leftPenlightId = leftPenlightStore((state) => state.id);
-  const rightPenlightId = rightPenlightStore((state) => state.id);
+  const getLeftPenlightId = leftPenlightStore((state) => state.getId);
+  const getRightPenlightId = rightPenlightStore((state) => state.getId);
 
   const moveToAnswer = () => {
     router.push(
       "/quiz/answer?colorIdLeft=" +
-        String(leftPenlightId) +
+        String(getLeftPenlightId()) +
         "&colorIdRight=" +
-        String(rightPenlightId)
+        String(getRightPenlightId())
     );
   };
 
@@ -112,8 +112,8 @@ function Penlight({ usePenlightStore }: penlightProps) {
 
   useEffect(() => {
     const penlightName = getPenlightName(penlightId);
-    penlightName.then((data)=>{
-      if(!data) return;
+    penlightName.then((data) => {
+      if (!data) return;
       setPenlightColorEn(data.nameEn);
       setPenlightColorJn(data.nameJa);
     });
@@ -122,7 +122,7 @@ function Penlight({ usePenlightStore }: penlightProps) {
   return (
     <div className="flex flex-col h-full w-full justify-center items-center">
       <div className="flex flex-col items-center w-1/4 h-4/5 border-2 rounded-md overflow-hidden">
-        <PenlightTop color={"bg-penlight_"+penlightColorEn} />
+        <PenlightTop color={"bg-penlight_" + penlightColorEn} />
         <PenlightBottom />
       </div>
       <div

--- a/view/src/zustand/penlightStore.tsx
+++ b/view/src/zustand/penlightStore.tsx
@@ -7,11 +7,13 @@ type PenlightIdType = {
 export type PenlightIdStore = PenlightIdType & {
   increaseId: () => void;
   decreaseId: () => void;
+  getId: () => number;
 };
 
 export const createPenlightStore = () =>
-  create<PenlightIdStore>((set) => ({
+  create<PenlightIdStore>((set, get) => ({
     id: 0,
     increaseId: () => set((state) => ({ id: (state.id + 1) % 15 })),
     decreaseId: () => set((state) => ({ id: (state.id - 1 + 15) % 15 })),
+    getId: () => get().id,
   }));


### PR DESCRIPTION
## 目的
[Fix Bug] 正しくペンライトIDがAnswer Pageに渡されない問題を解決
## 概要
クイズページからアンサーページ遷移する際に誤ったペンライトIDが送信され、
その結果正誤判定が誤ってしまう問題を解決した
## 確認項目

- [ ] ここに項目

## 不安・相談
